### PR TITLE
Improvements

### DIFF
--- a/library/src/main/java/me/toptas/fancyshowcase/DismissListener.java
+++ b/library/src/main/java/me/toptas/fancyshowcase/DismissListener.java
@@ -1,6 +1,19 @@
 package me.toptas.fancyshowcase;
 
+/**
+ * Listener for dismissing of one FancyShowCaseView
+ */
 public interface DismissListener {
+    /**
+     * is called when a {@link FancyShowCaseView} is dismissed
+     *
+     * @param id the one shot id of the dismissed view
+     */
     void onDismiss(String id);
+    /**
+     * is called when a {@link FancyShowCaseView} is skipped because of it's one shot id
+     *
+     * @param id the one shot id of the dismissed view
+     */
     void onSkipped(String id);
 }

--- a/library/src/main/java/me/toptas/fancyshowcase/DismissListener.java
+++ b/library/src/main/java/me/toptas/fancyshowcase/DismissListener.java
@@ -1,0 +1,9 @@
+package me.toptas.fancyshowcase;
+
+/**
+ * Created by Michael on 26.03.2017.
+ */
+
+public interface DismissListener {
+    void onDismiss(String id);
+}

--- a/library/src/main/java/me/toptas/fancyshowcase/DismissListener.java
+++ b/library/src/main/java/me/toptas/fancyshowcase/DismissListener.java
@@ -1,9 +1,5 @@
 package me.toptas.fancyshowcase;
 
-/**
- * Created by Michael on 26.03.2017.
- */
-
 public interface DismissListener {
     void onDismiss(String id);
 }

--- a/library/src/main/java/me/toptas/fancyshowcase/DismissListener.java
+++ b/library/src/main/java/me/toptas/fancyshowcase/DismissListener.java
@@ -7,13 +7,13 @@ public interface DismissListener {
     /**
      * is called when a {@link FancyShowCaseView} is dismissed
      *
-     * @param id the one shot id of the dismissed view
+     * @param id the show once id of the dismissed view
      */
     void onDismiss(String id);
     /**
      * is called when a {@link FancyShowCaseView} is skipped because of it's one shot id
      *
-     * @param id the one shot id of the dismissed view
+     * @param id the show once id of the dismissed view
      */
     void onSkipped(String id);
 }

--- a/library/src/main/java/me/toptas/fancyshowcase/DismissListener.java
+++ b/library/src/main/java/me/toptas/fancyshowcase/DismissListener.java
@@ -2,4 +2,5 @@ package me.toptas.fancyshowcase;
 
 public interface DismissListener {
     void onDismiss(String id);
+    void onSkipped(String id);
 }

--- a/library/src/main/java/me/toptas/fancyshowcase/DismissListener.java
+++ b/library/src/main/java/me/toptas/fancyshowcase/DismissListener.java
@@ -11,7 +11,7 @@ public interface DismissListener {
      */
     void onDismiss(String id);
     /**
-     * is called when a {@link FancyShowCaseView} is skipped because of it's one shot id
+     * is called when a {@link FancyShowCaseView} is skipped because of it's show once id
      *
      * @param id the show once id of the dismissed view
      */

--- a/library/src/main/java/me/toptas/fancyshowcase/FancyShowCaseQueue.java
+++ b/library/src/main/java/me/toptas/fancyshowcase/FancyShowCaseQueue.java
@@ -3,21 +3,37 @@ package me.toptas.fancyshowcase;
 import java.util.LinkedList;
 import java.util.Queue;
 
+/**
+ * Handles queues of {@link FancyShowCaseView} so that they are shown one after another
+ * takes care to skip views that should not be shown because of their one shot id
+ */
 public class FancyShowCaseQueue implements DismissListener {
 
     private Queue<FancyShowCaseView> mQueue;
     private DismissListener mCurrentOriginalDismissListener;
 
+    /**
+     * Constructor
+     */
     public FancyShowCaseQueue() {
         mQueue = new LinkedList<>();
         mCurrentOriginalDismissListener = null;
     }
 
+    /**
+     * adds a view to the queue
+     *
+     * @param showCaseView the view that should be added to the queue
+     * @return Builder
+     */
     public FancyShowCaseQueue add(FancyShowCaseView showCaseView) {
         mQueue.add(showCaseView);
         return this;
     }
 
+    /**
+     * starts displaying all views in order of their insertion in the queue, one after another
+     */
     public void show() {
         if (!mQueue.isEmpty()) {
             FancyShowCaseView view = mQueue.poll();

--- a/library/src/main/java/me/toptas/fancyshowcase/FancyShowCaseQueue.java
+++ b/library/src/main/java/me/toptas/fancyshowcase/FancyShowCaseQueue.java
@@ -1,0 +1,45 @@
+package me.toptas.fancyshowcase;
+
+import java.util.LinkedList;
+import java.util.Queue;
+
+public class FancyShowCaseQueue implements DismissListener {
+
+    private Queue<FancyShowCaseView> mQueue;
+    private DismissListener mCurrentOriginalDismissListener;
+
+    public FancyShowCaseQueue() {
+        mQueue = new LinkedList<>();
+        mCurrentOriginalDismissListener = null;
+    }
+
+    public FancyShowCaseQueue add(FancyShowCaseView showCaseView) {
+        mQueue.add(showCaseView);
+        return this;
+    }
+
+    public void show() {
+        if (!mQueue.isEmpty()) {
+            FancyShowCaseView view = mQueue.poll();
+            mCurrentOriginalDismissListener = view.getDismissListener();
+            view.setDismissListener(this);
+            view.show();
+        }
+    }
+
+    @Override
+    public void onDismiss(String id) {
+        if (mCurrentOriginalDismissListener != null) {
+            mCurrentOriginalDismissListener.onDismiss(id);
+        }
+        show();
+    }
+
+    @Override
+    public void onSkipped(String id) {
+        if (mCurrentOriginalDismissListener != null) {
+            mCurrentOriginalDismissListener.onSkipped(id);
+        }
+        show();
+    }
+}

--- a/library/src/main/java/me/toptas/fancyshowcase/FancyShowCaseView.java
+++ b/library/src/main/java/me/toptas/fancyshowcase/FancyShowCaseView.java
@@ -76,6 +76,7 @@ public class FancyShowCaseView {
     private boolean mCloseOnTouch;
     private boolean mFitSystemWindows;
     private FocusShape mFocusShape;
+    private DismissListener mDismissListener;
 
 
     private int mAnimationDuration = 400;
@@ -103,13 +104,14 @@ public class FancyShowCaseView {
      * @param closeOnTouch            closes on touch if enabled
      * @param fitSystemWindows        should be the same value of root view's fitSystemWindows value
      * @param focusShape              shape of focus, can be circle or rounded rectangle
+     * @param dismissListener         listener that gets notified when showcase is dismissed
      */
     private FancyShowCaseView(Activity activity, View view, String id, String title,
                               int titleGravity, int titleStyle, double focusCircleRadiusFactor,
                               int backgroundColor, int customViewRes,
                               OnViewInflateListener viewInflateListener, Animation enterAnimation,
                               Animation exitAnimation, boolean closeOnTouch, boolean fitSystemWindows,
-                              FocusShape focusShape) {
+                              FocusShape focusShape, DismissListener dismissListener) {
         mId = id;
         mActivity = activity;
         mView = view;
@@ -125,6 +127,7 @@ public class FancyShowCaseView {
         mCloseOnTouch = closeOnTouch;
         mFitSystemWindows = fitSystemWindows;
         mFocusShape = focusShape;
+        mDismissListener = dismissListener;
 
         initializeParameters();
     }
@@ -362,6 +365,8 @@ public class FancyShowCaseView {
      */
     public void removeView() {
         mRoot.removeView(mContainer);
+        if (mDismissListener != null)
+            mDismissListener.onDismiss(mId);
     }
 
     /**
@@ -402,6 +407,7 @@ public class FancyShowCaseView {
         private boolean mCloseOnTouch = true;
         private boolean mFitSystemWindows;
         private FocusShape mFocusShape = FocusShape.CIRCLE;
+        private DismissListener mDismissListener = null;
 
         /**
          * Constructor for Builder class
@@ -524,6 +530,15 @@ public class FancyShowCaseView {
         }
 
         /**
+         * @param dismissListener the dismiss listener
+         * @return Builder
+         */
+        public Builder dismissListener(DismissListener dismissListener) {
+            mDismissListener = dismissListener;
+            return this;
+        }
+
+        /**
          * builds the builder
          *
          * @return {@link FancyShowCaseView} with given parameters
@@ -531,7 +546,7 @@ public class FancyShowCaseView {
         public FancyShowCaseView build() {
             return new FancyShowCaseView(mActivity, mView, mId, mTitle, mTitleGravity, mTitleStyle,
                     mFocusCircleRadiusFactor, mBackgroundColor, mCustomViewRes, mViewInflateListener,
-                    mEnterAnimation, mExitAnimation, mCloseOnTouch, mFitSystemWindows, mFocusShape);
+                    mEnterAnimation, mExitAnimation, mCloseOnTouch, mFitSystemWindows, mFocusShape, mDismissListener);
         }
     }
 }

--- a/library/src/main/java/me/toptas/fancyshowcase/FancyShowCaseView.java
+++ b/library/src/main/java/me/toptas/fancyshowcase/FancyShowCaseView.java
@@ -13,6 +13,7 @@ import android.support.annotation.Nullable;
 import android.support.annotation.RequiresApi;
 import android.support.annotation.StyleRes;
 import android.util.DisplayMetrics;
+import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewAnimationUtils;
@@ -70,6 +71,8 @@ public class FancyShowCaseView {
     private int mBackgroundColor;
     private int mTitleGravity;
     private int mTitleStyle;
+    private int mTitleSize;
+    private int mTitleSizeUnit;
     private int mCustomViewRes;
     private OnViewInflateListener mViewInflateListener;
     private Animation mEnterAnimation, mExitAnimation;
@@ -95,6 +98,8 @@ public class FancyShowCaseView {
      * @param title                   title text
      * @param titleGravity            title gravity
      * @param titleStyle              title text style
+     * @param titleSize               title text size
+     * @param titleSizeUnit           title text size unit
      * @param focusCircleRadiusFactor focus circle radius factor (default value = 1)
      * @param backgroundColor         background color of FancyShowCaseView
      * @param customViewRes           custom view layout resource
@@ -107,7 +112,7 @@ public class FancyShowCaseView {
      * @param dismissListener         listener that gets notified when showcase is dismissed
      */
     private FancyShowCaseView(Activity activity, View view, String id, String title,
-                              int titleGravity, int titleStyle, double focusCircleRadiusFactor,
+                              int titleGravity, int titleStyle, int titleSize, int titleSizeUnit, double focusCircleRadiusFactor,
                               int backgroundColor, int customViewRes,
                               OnViewInflateListener viewInflateListener, Animation enterAnimation,
                               Animation exitAnimation, boolean closeOnTouch, boolean fitSystemWindows,
@@ -120,6 +125,8 @@ public class FancyShowCaseView {
         mBackgroundColor = backgroundColor;
         mTitleGravity = titleGravity;
         mTitleStyle = titleStyle;
+        mTitleSize = titleSize;
+        mTitleSizeUnit = titleSizeUnit;
         mCustomViewRes = customViewRes;
         mViewInflateListener = viewInflateListener;
         mEnterAnimation = enterAnimation;
@@ -155,6 +162,9 @@ public class FancyShowCaseView {
      */
     public void show() {
         if (mActivity == null || (mId != null && isShownBefore())) {
+            if (mDismissListener != null) {
+                mDismissListener.onSkipped(mId);
+            }
             return;
         }
 
@@ -283,6 +293,9 @@ public class FancyShowCaseView {
                 } else {
                     textView.setTextAppearance(mActivity, mTitleStyle);
                 }
+                if (mTitleSize != -1) {
+                    textView.setTextSize(mTitleSizeUnit, mTitleSize);
+                }
                 textView.setGravity(mTitleGravity);
                 textView.setText(mTitle);
             }
@@ -388,6 +401,14 @@ public class FancyShowCaseView {
         return mContainer;
     }
 
+    protected DismissListener getDismissListener() {
+        return mDismissListener;
+    }
+
+    protected void setDismissListener(DismissListener dismissListener) {
+        mDismissListener = dismissListener;
+    }
+
 
     /**
      * Builder class for {@link FancyShowCaseView}
@@ -401,6 +422,8 @@ public class FancyShowCaseView {
         private double mFocusCircleRadiusFactor = 1;
         private int mBackgroundColor;
         private int mTitleGravity = -1;
+        private int mTitleSize = -1;
+        private int mTitleSizeUnit = -1;
         private int mTitleStyle;
         private int mCustomViewRes;
         private OnViewInflateListener mViewInflateListener;
@@ -437,6 +460,35 @@ public class FancyShowCaseView {
         public Builder titleStyle(@StyleRes int style, int titleGravity) {
             mTitleGravity = titleGravity;
             mTitleStyle = style;
+            return this;
+        }
+
+        /**
+         * @param titleGravity title gravity
+         * @return Builder
+         */
+        public Builder titleGravity(int titleGravity) {
+            mTitleGravity = titleGravity;
+            return this;
+        }
+
+        /**
+         * @param titleSize title size, overrides any defined size in the default or provided style
+         * @return Builder
+         */
+        public Builder titleSizePx(int titleSize) {
+            mTitleSize = titleSize;
+            mTitleSizeUnit = TypedValue.COMPLEX_UNIT_PX;
+            return this;
+        }
+
+        /**
+         * @param titleSize title size, overrides any defined size in the default or provided style
+         * @return Builder
+         */
+        public Builder titleSizeSp(int titleSize) {
+            mTitleSize = titleSize;
+            mTitleSizeUnit = TypedValue.COMPLEX_UNIT_SP;
             return this;
         }
 
@@ -545,7 +597,7 @@ public class FancyShowCaseView {
          * @return {@link FancyShowCaseView} with given parameters
          */
         public FancyShowCaseView build() {
-            return new FancyShowCaseView(mActivity, mView, mId, mTitle, mTitleGravity, mTitleStyle,
+            return new FancyShowCaseView(mActivity, mView, mId, mTitle, mTitleGravity, mTitleStyle, mTitleSize, mTitleSizeUnit,
                     mFocusCircleRadiusFactor, mBackgroundColor, mCustomViewRes, mViewInflateListener,
                     mEnterAnimation, mExitAnimation, mCloseOnTouch, mFitSystemWindows, mFocusShape, mDismissListener);
         }

--- a/library/src/main/java/me/toptas/fancyshowcase/FancyShowCaseView.java
+++ b/library/src/main/java/me/toptas/fancyshowcase/FancyShowCaseView.java
@@ -365,8 +365,9 @@ public class FancyShowCaseView {
      */
     public void removeView() {
         mRoot.removeView(mContainer);
-        if (mDismissListener != null)
+        if (mDismissListener != null) {
             mDismissListener.onDismiss(mId);
+        }
     }
 
     /**

--- a/library/src/main/java/me/toptas/fancyshowcase/FancyShowCaseView.java
+++ b/library/src/main/java/me/toptas/fancyshowcase/FancyShowCaseView.java
@@ -54,7 +54,7 @@ public class FancyShowCaseView {
      *
      * @param context context that should be used to create the shared preference instance
      */
-    public static void resetAllShowOnce(Context context, String id) {
+    public static void resetAllShowOnce(Context context) {
         SharedPreferences sharedPrefs = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE);
         sharedPrefs.edit().clear().commit();
         return;

--- a/library/src/main/java/me/toptas/fancyshowcase/FancyShowCaseView.java
+++ b/library/src/main/java/me/toptas/fancyshowcase/FancyShowCaseView.java
@@ -37,6 +37,29 @@ public class FancyShowCaseView {
     private static final String PREF_NAME = "PrefShowCaseView";
 
     /**
+     * resets the show once flag
+     *
+     * @param context context that should be used to create the shared preference instance
+     * @param id id of the show once flag that should be reset
+     */
+    public static void resetShowOnce(Context context, String id) {
+        SharedPreferences sharedPrefs = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE);
+        sharedPrefs.edit().remove(id).commit();
+        return;
+    }
+
+    /**
+     * resets all show once flags
+     *
+     * @param context context that should be used to create the shared preference instance
+     */
+    public static void resetAllShowOnce(Context context, String id) {
+        SharedPreferences sharedPrefs = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE);
+        sharedPrefs.edit().clear().commit();
+        return;
+    }
+
+    /**
      * Builder parameters
      */
     private final Activity mActivity;

--- a/library/src/main/java/me/toptas/fancyshowcase/FancyShowCaseView.java
+++ b/library/src/main/java/me/toptas/fancyshowcase/FancyShowCaseView.java
@@ -473,22 +473,14 @@ public class FancyShowCaseView {
         }
 
         /**
-         * @param titleSize title size, overrides any defined size in the default or provided style
+         * the defined text size overrides any defined size in the default or provided style
+         * @param titleSize title size
+         * @param unit title text unit
          * @return Builder
          */
-        public Builder titleSizePx(int titleSize) {
+        public Builder titleSize(int titleSize, int unit) {
             mTitleSize = titleSize;
-            mTitleSizeUnit = TypedValue.COMPLEX_UNIT_PX;
-            return this;
-        }
-
-        /**
-         * @param titleSize title size, overrides any defined size in the default or provided style
-         * @return Builder
-         */
-        public Builder titleSizeSp(int titleSize) {
-            mTitleSize = titleSize;
-            mTitleSizeUnit = TypedValue.COMPLEX_UNIT_SP;
+            mTitleSizeUnit = unit;
             return this;
         }
 


### PR DESCRIPTION
Changes made in dev branch now to solve following issues:
https://github.com/faruktoptas/FancyShowCaseView/issues/17
https://github.com/faruktoptas/FancyShowCaseView/issues/18
And some small improvements/extensions...

DONE:
* added static functions to reset the show once flag
* DismissListener added
* basic simple FancyShowCaseQueue, for queuing FancyShowCaseViews respecting showOnce flag anywhere in the queue
* support for overwriting the default text size
* added an own setter for title gravity
* added a setter for overwriting the title text size (I think, most people are content with the default style but only want texts in a different size)

IMPROVEMENTS:
* group ids for queues? Probably those would make sense to show a group only once...
* Animation from one ShowCaseView to the next could be improved, i.e. close the focused area with the background color and open the new focused area + fading out the old text and fading in the new one