### PR TITLE
Added listener interface for queue completion

### DIFF
--- a/library/src/main/java/me/toptas/fancyshowcase/FancyShowCaseQueue.java
+++ b/library/src/main/java/me/toptas/fancyshowcase/FancyShowCaseQueue.java
@@ -12,6 +12,7 @@ public class FancyShowCaseQueue implements DismissListener {
     private Queue<FancyShowCaseView> mQueue;
     private DismissListener mCurrentOriginalDismissListener;
     private FancyShowCaseView mCurrent;
+    private OnCompleteListener mCompleteListener;
 
     /**
      * Constructor
@@ -19,6 +20,7 @@ public class FancyShowCaseQueue implements DismissListener {
     public FancyShowCaseQueue() {
         mQueue = new LinkedList<>();
         mCurrentOriginalDismissListener = null;
+        mCompleteListener = null;
     }
 
     /**
@@ -41,6 +43,8 @@ public class FancyShowCaseQueue implements DismissListener {
             mCurrentOriginalDismissListener = mCurrent.getDismissListener();
             mCurrent.setDismissListener(this);
             mCurrent.show();
+        } else if (mCompleteListener != null) {
+            mCompleteListener.onComplete();
         }
     }
 
@@ -71,5 +75,9 @@ public class FancyShowCaseQueue implements DismissListener {
             mCurrentOriginalDismissListener.onSkipped(id);
         }
         show();
+    }
+
+    public void setCompleteListener(OnCompleteListener completeListener) {
+        mCompleteListener = completeListener;
     }
 }

--- a/library/src/main/java/me/toptas/fancyshowcase/FancyShowCaseQueue.java
+++ b/library/src/main/java/me/toptas/fancyshowcase/FancyShowCaseQueue.java
@@ -20,7 +20,6 @@ public class FancyShowCaseQueue implements DismissListener {
     public FancyShowCaseQueue() {
         mQueue = new LinkedList<>();
         mCurrentOriginalDismissListener = null;
-        mCompleteListener = null;
     }
 
     /**

--- a/library/src/main/java/me/toptas/fancyshowcase/OnCompleteListener.java
+++ b/library/src/main/java/me/toptas/fancyshowcase/OnCompleteListener.java
@@ -1,0 +1,9 @@
+package me.toptas.fancyshowcase;
+
+/**
+ * Listener for FancyShowCaseQueue completion
+ */
+
+public interface OnCompleteListener {
+    public void onComplete();
+}


### PR DESCRIPTION
This basic functionality should fix #49 . An alternative implementation could include a flag that is set when a view is shown (and therefore only call the completion listener after at least one view has been shown), and/or add a function to the interface to be called when the queue is cancelled.