### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -2,8 +2,7 @@
     package="me.toptas.fancyshowcase">
 
     <application
-        android:label="@string/app_name"
-        android:supportsRtl="true">
+        android:label="@string/app_name">
 
     </application>
 


### PR DESCRIPTION
Remove application attribute.
At the moment each consumer of the lib inherits the following attribute (unless they remove them in the manifest merger)

* supportsRtl