### PR TITLE
Issue/74 focus in oncreate

### DIFF
--- a/app/src/main/java/me/toptas/fancyshowcasesample/SecondActivity.java
+++ b/app/src/main/java/me/toptas/fancyshowcasesample/SecondActivity.java
@@ -24,7 +24,7 @@ public class SecondActivity extends BaseActivity {
         ButterKnife.bind(this);
         setSupportActionBar(mToolbar);
 
-        mButton.performClick();
+        focusOnButton();
     }
 
     /**
@@ -33,13 +33,17 @@ public class SecondActivity extends BaseActivity {
     @OnClick(R.id.button1)
     public void focus() {
         if (!isFinishing()) {
-            new FancyShowCaseView.Builder(SecondActivity.this)
-                    .focusOn(mButton)
-                    .title("Focus a view")
-                    .fitSystemWindows(true)
-                    .build()
-                    .show();
+            focusOnButton();
         }
+    }
+
+    private void focusOnButton() {
+        new FancyShowCaseView.Builder(SecondActivity.this)
+                .focusOn(mButton)
+                .title("Focus a view")
+                .fitSystemWindows(true)
+                .build()
+                .show();
     }
 
     /**

--- a/library/src/main/java/me/toptas/fancyshowcase/FancyShowCaseView.java
+++ b/library/src/main/java/me/toptas/fancyshowcase/FancyShowCaseView.java
@@ -407,11 +407,15 @@ public class FancyShowCaseView extends FrameLayout implements ViewTreeObserver.O
      */
     @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
     private void doCircularEnterAnimation() {
-        getViewTreeObserver().addOnPreDrawListener(
-                new ViewTreeObserver.OnPreDrawListener() {
+        getViewTreeObserver().addOnGlobalLayoutListener(
+                new ViewTreeObserver.OnGlobalLayoutListener() {
                     @Override
-                    public boolean onPreDraw() {
-                        getViewTreeObserver().removeOnPreDrawListener(this);
+                    public void onGlobalLayout() {
+                        if (Build.VERSION.SDK_INT < 16) {
+                            getViewTreeObserver().removeGlobalOnLayoutListener(this);
+                        } else {
+                            getViewTreeObserver().removeOnGlobalLayoutListener(this);
+                        }
 
                         final int revealRadius = (int) Math.hypot(
                                 getWidth(), getHeight());
@@ -428,7 +432,6 @@ public class FancyShowCaseView extends FrameLayout implements ViewTreeObserver.O
                         enterAnimator.setInterpolator(AnimationUtils.loadInterpolator(mActivity,
                                 android.R.interpolator.accelerate_cubic));
                         enterAnimator.start();
-                        return false;
                     }
                 });
 


### PR DESCRIPTION
In c871536c650ebc137cb51cfc6baffe9a939f4cd8, I modified the example app to demonstrate the problem I was having. Namely, if I create and show a `FancyShowCaseView` in an activity's `onCreate` on an API 21 device, then the circular reveal enter animation doesn't show. The existing code was calling `mButton.performClick()` which must post something on the UI thread, and doesn't reveal the problem. 

In the subsequent commit, my fix to the circular reveal enter animation was to switch from the `onPreDraw()` listener to the `onGlobalLayout()` listener.

Resolves #74