### PR TITLE
Release memory used by bitmap

### DIFF
--- a/library/src/main/java/me/toptas/fancyshowcase/FancyImageView.java
+++ b/library/src/main/java/me/toptas/fancyshowcase/FancyImageView.java
@@ -202,4 +202,13 @@ class FancyImageView extends AppCompatImageView {
         mFocusAnimationMaxValue = maxValue;
         mFocusAnimationStep = step;
     }
+
+    @Override
+    protected void onDetachedFromWindow() {
+        super.onDetachedFromWindow();
+        if (mBitmap!=null && !mBitmap.isRecycled()){
+            mBitmap.recycle();
+            mBitmap=null;
+        }
+    }
 }

--- a/library/src/main/java/me/toptas/fancyshowcase/FancyShowCaseView.java
+++ b/library/src/main/java/me/toptas/fancyshowcase/FancyShowCaseView.java
@@ -120,6 +120,7 @@ public class FancyShowCaseView extends FrameLayout implements ViewTreeObserver.O
     private float[] mLastTouchDownXY = new float[2];
 
     private boolean mFocusAnimationEnabled;
+    FancyImageView mImageView;
 
     /**
      * Constructor for FancyShowCaseView
@@ -267,29 +268,29 @@ public class FancyShowCaseView extends FrameLayout implements ViewTreeObserver.O
                     mRoot.addView(FancyShowCaseView.this);
 
 
-                    FancyImageView imageView = new FancyImageView(mActivity);
-                    imageView.setFocusAnimationParameters(mFocusAnimationMaxValue, mFocusAnimationStep);
+                    mImageView = new FancyImageView(mActivity);
+                    mImageView.setFocusAnimationParameters(mFocusAnimationMaxValue, mFocusAnimationStep);
                     if (mCalculator.hasFocus()) {
                         mCenterX = mCalculator.getCircleCenterX();
                         mCenterY = mCalculator.getCircleCenterY();
                     }
-                    imageView.setParameters(mBackgroundColor, mCalculator);
+                    mImageView.setParameters(mBackgroundColor, mCalculator);
                     if (mFocusRectangleWidth > 0 && mFocusRectangleHeight > 0) {
                         mCalculator.setRectPosition(mFocusPositionX, mFocusPositionY, mFocusRectangleWidth, mFocusRectangleHeight);
                     }
                     if (mFocusCircleRadius > 0) {
                         mCalculator.setCirclePosition(mFocusPositionX, mFocusPositionY, mFocusCircleRadius);
                     }
-                    imageView.setAnimationEnabled(mFocusAnimationEnabled);
-                    imageView.setLayoutParams(new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
+                    mImageView.setAnimationEnabled(mFocusAnimationEnabled);
+                    mImageView.setLayoutParams(new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
                             ViewGroup.LayoutParams.MATCH_PARENT));
                     if (mFocusBorderColor != 0 && mFocusBorderSize > 0) {
-                        imageView.setBorderParameters(mFocusBorderColor, mFocusBorderSize);
+                        mImageView.setBorderParameters(mFocusBorderColor, mFocusBorderSize);
                     }
                     if (mRoundRectRadius > 0) {
-                        imageView.setRoundRectRadius(mRoundRectRadius);
+                        mImageView.setRoundRectRadius(mRoundRectRadius);
                     }
-                    addView(imageView);
+                    addView(mImageView);
 
 
                     if (mCustomViewRes == 0) {
@@ -589,6 +590,8 @@ public class FancyShowCaseView extends FrameLayout implements ViewTreeObserver.O
      * Removes FancyShowCaseView view from activity root view
      */
     public void removeView() {
+        if (mImageView!=null)
+            mImageView=null;
         mRoot.removeView(this);
         if (mDismissListener != null) {
             mDismissListener.onDismiss(mId);


### PR DESCRIPTION
I have created this PR to free the memory used by the bitmaps. In the case of native android does not affect the performance so much because the GC removes the references, however when create java binding for Xamarin Android, C# maintains strong references to the bitmaps so the GC of the Java VM does not release that memory and produces crash. However it is always good to free the memory used by bitmap to avoid crashes.