### PR TITLE
Couple of minor details

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ allprojects {
 Then, add the library to your module `build.gradle`
 ```gradle
 dependencies {
-    compile 'com.github.faruktoptas:FancyShowCaseView:1.0.0'
+    implementation 'com.github.faruktoptas:FancyShowCaseView:1.0.0'
 }
 ```
 

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,9 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="me.toptas.fancyshowcase">
-
-    <application
-        android:label="@string/app_name">
-
-    </application>
-
-</manifest>
+<manifest package="me.toptas.fancyshowcase"/>


### PR DESCRIPTION
- swapped compile for implementation in the readme
Just to comply with new methods.

- removed label from library manifest
Manifest definitions are a common cause for manifest merge conflicts on the app using the library, especially the ones defined for application, so leaving it "empty" when possible will avoid conflict if the app is using different values.