### PR TITLE
Replaced deprecated compile by implementation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,10 +32,10 @@ android {
 
 dependencies {
 
-    compile "com.android.support:appcompat-v7:$support_version"
-    compile "com.android.support:design:$support_version"
-    compile "com.jakewharton:butterknife:$butterknife_version"
+    implementation "com.android.support:appcompat-v7:$support_version"
+    implementation "com.android.support:design:$support_version"
+    implementation "com.jakewharton:butterknife:$butterknife_version"
     annotationProcessor "com.jakewharton:butterknife-compiler:$butterknife_version"
 
-    compile project(':library')
+    implementation project(':library')
 }


### PR DESCRIPTION
As the compile configuration is now deprecated, replaced it by implementation.