### PR TITLE
Add support of fitSystemWindows(true) for KitKat.

### DIFF
--- a/library/src/main/java/me/toptas/fancyshowcase/Calculator.kt
+++ b/library/src/main/java/me/toptas/fancyshowcase/Calculator.kt
@@ -83,7 +83,7 @@ class Calculator(activity: Activity,
         bitmapWidth = deviceWidth
         bitmapHeight = deviceHeight - if (fitSystemWindows) 0 else getStatusBarHeight(activity)
         if (view != null) {
-            val adjustHeight = if (fitSystemWindows && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
+            val adjustHeight = if (fitSystemWindows && Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT)
                 0
             else
                 getStatusBarHeight(activity)


### PR DESCRIPTION
`fitSystemWindows(true)` has no effect on KitKat currently.

That's because the `adjustHeight` val in `Calculator.kt` is true only for LOLLIPOP+ APIs (see commit changes). As a result the solution for the following issues (adding `fitSystemWindows(true)` to the `FancyShowCaseView.Builder`) is not working:

[Focus not centered at the actionbar item](https://github.com/faruktoptas/FancyShowCaseView/issues/91)
[please help me，the focus view is show this，the location is wrong](https://github.com/faruktoptas/FancyShowCaseView/issues/86)