### PR TITLE
Fix enable touch on focus zone

### DIFF
--- a/fancyshowcaseview/src/main/java/me/toptas/fancyshowcase/FancyShowCaseView.kt
+++ b/fancyshowcaseview/src/main/java/me/toptas/fancyshowcase/FancyShowCaseView.kt
@@ -51,7 +51,8 @@ import me.toptas.fancyshowcase.listener.OnViewInflateListener
  * FancyShowCaseView class
  */
 
-class FancyShowCaseView : FrameLayout, ViewTreeObserver.OnGlobalLayoutListener {
+class FancyShowCaseView @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null, @AttrRes defStyleAttr: Int = 0)
+    : FrameLayout(context, attrs, defStyleAttr), ViewTreeObserver.OnGlobalLayoutListener {
 
     /**
      * Builder parameters
@@ -62,6 +63,7 @@ class FancyShowCaseView : FrameLayout, ViewTreeObserver.OnGlobalLayoutListener {
     private var id: String? = null
     private var focusCircleRadiusFactor: Double = 1.0
     private var focusedView: View? = null
+    private var clickableView: View? = null
     private var mBackgroundColor: Int = 0
     private var mFocusBorderColor: Int = 0
     private var mTitleGravity: Int = -1
@@ -88,7 +90,8 @@ class FancyShowCaseView : FrameLayout, ViewTreeObserver.OnGlobalLayoutListener {
     private var mCenterY: Int = 0
     private var mRoot: ViewGroup? = null
     private var sharedPreferences: SharedPreferences? = null
-    private var calculator: Calculator? = null
+    private var focusCalculator: Calculator? = null
+    private var clickableCalculator: Calculator? = null
     private var mFocusPositionX: Int = 0
     private var mFocusPositionY: Int = 0
     private var mFocusCircleRadius: Int = 0
@@ -98,32 +101,12 @@ class FancyShowCaseView : FrameLayout, ViewTreeObserver.OnGlobalLayoutListener {
     private var fancyImageView: FancyImageView? = null
     var dismissListener: DismissListener? = null
 
-    val focusCenterX = calculator?.circleCenterX ?: 0
-
-    val focusCenterY = calculator?.circleCenterY ?: 0
-
-    val focusRadius = if (FocusShape.CIRCLE == mFocusShape)
-        calculator?.circleRadius(0, 1.0) ?: 0f
-    else 0f
-
-    val focusWidth = calculator?.focusWidth ?: 0
-
-    val focusHeight = calculator?.focusHeight ?: 0
-
-    internal constructor(context: Context) : super(context)
-
-    internal constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
-
-    internal constructor(context: Context, attrs: AttributeSet?, @AttrRes defStyleAttr: Int) : super(context, attrs, defStyleAttr)
-
-    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
-    internal constructor(context: Context, attrs: AttributeSet?, @AttrRes defStyleAttr: Int, @StyleRes defStyleRes: Int) : super(context, attrs, defStyleAttr, defStyleRes)
-
     /**
      * Constructor for FancyShowCaseView
      *
      * @param _activity                 Activity to show FancyShowCaseView in
-     * @param _view                     view to focus
+     * @param _focusView                view to focus
+     * @param _clickableView            view to be clickable
      * @param _id                       unique identifier for FancyShowCaseView
      * @param _title                    title text
      * @param _spannedTitle             title text if spanned text should be used
@@ -153,7 +136,8 @@ class FancyShowCaseView : FrameLayout, ViewTreeObserver.OnGlobalLayoutListener {
      * @param _animationEnabled         flag to enable/disable animation
      */
     private constructor(_activity: Activity,
-                        _view: View?,
+                        _focusView: View?,
+                        _clickableView: View?,
                         _id: String?,
                         _title: String?,
                         _spannedTitle: Spanned?,
@@ -185,12 +169,13 @@ class FancyShowCaseView : FrameLayout, ViewTreeObserver.OnGlobalLayoutListener {
                         _focusAnimationMaxValue: Int,
                         _focusAnimationStep: Int,
                         _delay: Long,
-                        _autoPosText: Boolean) : super(_activity) {
+                        _autoPosText: Boolean) : this(_activity) {
 
         requireNotNull(_activity)
         id = _id
         activity = _activity
-        focusedView = _view
+        focusedView = _focusView
+        clickableView = _clickableView
         title = _title
         spannedTitle = _spannedTitle
         focusCircleRadiusFactor = _focusCircleRadiusFactor
@@ -263,9 +248,15 @@ class FancyShowCaseView : FrameLayout, ViewTreeObserver.OnGlobalLayoutListener {
     }
 
     private fun focus() {
-        calculator = Calculator(activity,
+        focusCalculator = Calculator(activity,
                 mFocusShape,
                 focusedView,
+                focusCircleRadiusFactor,
+                fitSystemWindows)
+
+        clickableCalculator = Calculator(activity,
+                mFocusShape,
+                clickableView,
                 focusCircleRadiusFactor,
                 fitSystemWindows)
 
@@ -280,12 +271,12 @@ class FancyShowCaseView : FrameLayout, ViewTreeObserver.OnGlobalLayoutListener {
             if (visibleView == null) {
                 tag = CONTAINER_TAG
                 setId(R.id.fscv_id)
-                if (mCloseOnTouch) {
-                    setupTouchListener()
-                }
+
                 layoutParams = ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
                         ViewGroup.LayoutParams.MATCH_PARENT)
                 mRoot?.addView(this)
+
+                setupTouchListener()
 
                 setCalculatorParams()
 
@@ -301,7 +292,7 @@ class FancyShowCaseView : FrameLayout, ViewTreeObserver.OnGlobalLayoutListener {
     }
 
     private fun setCalculatorParams() {
-        calculator?.apply {
+        focusCalculator?.apply {
             if (hasFocus()) {
                 mCenterX = circleCenterX
                 mCenterY = circleCenterY
@@ -318,7 +309,7 @@ class FancyShowCaseView : FrameLayout, ViewTreeObserver.OnGlobalLayoutListener {
     private fun addFancyImageView() {
         FancyImageView(activity).apply {
             setFocusAnimationParameters(mFocusAnimationMaxValue, mFocusAnimationStep)
-            setParameters(mBackgroundColor, calculator!!)
+            setParameters(mBackgroundColor, focusCalculator!!)
             focusAnimationEnabled = this@FancyShowCaseView.focusAnimationEnabled
             layoutParams = FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
                     ViewGroup.LayoutParams.MATCH_PARENT)
@@ -341,46 +332,66 @@ class FancyShowCaseView : FrameLayout, ViewTreeObserver.OnGlobalLayoutListener {
     }
 
     private fun setupTouchListener() {
-        if (mEnableTouchOnFocusedView) {
-            setOnTouchListener(OnTouchListener { _, event ->
-                if (event.actionMasked == MotionEvent.ACTION_DOWN) {
-                    var isWithin = false
-                    val x = event.x
-                    val y = event.y
-
-                    when (mFocusShape) {
-                        FocusShape.CIRCLE -> {
-                            val distance = Math.sqrt(
-                                    Math.pow((focusCenterX - x).toDouble(), 2.0) + Math.pow((focusCenterY - y).toDouble(), 2.0))
-
-                            isWithin = Math.abs(distance) < focusRadius
-                        }
-                        FocusShape.ROUNDED_RECTANGLE -> {
-                            val rect = Rect()
-                            val left = focusCenterX - focusWidth / 2
-                            val right = focusCenterX + focusWidth / 2
-                            val top = focusCenterY - focusHeight / 2
-                            val bottom = focusCenterY + focusHeight / 2
-                            rect.set(left, top, right, bottom)
-                            isWithin = rect.contains(x.toInt(), y.toInt())
-                        }
-                    }
-
-                    // let the touch event pass on to whoever needs it
-                    if (isWithin) {
-                        return@OnTouchListener false
-                    } else {
-                        if (mCloseOnTouch) {
+        setOnTouchListener(OnTouchListener { _, event ->
+            if (event.actionMasked == MotionEvent.ACTION_DOWN) {
+                when {
+                    mEnableTouchOnFocusedView -> {
+                        if (isWithinZone(event, focusCalculator)) {
+                            // Check if there is a clickable view within the focusable view
+                            // Let the touch event pass through to clickable zone only if clicking within, otherwise return true to ignore event
+                            // If there is no clickable view we let through the click to the focusable view
+                            clickableView?.let {
+                                return@OnTouchListener !isWithinZone(event, clickableCalculator)
+                            } ?: return@OnTouchListener false
+                        } else if (mCloseOnTouch) {
                             hide()
                         }
                     }
+                    mCloseOnTouch -> hide()
                 }
-                true
-            })
-        } else {
-            setOnClickListener { hide() }
+            }
+            true
+        })
+    }
+
+    /**
+     * Check whether the event is within the provided zone that was already computed with the provided calculator
+     *
+     * @param event         The event from onTouch callback
+     * @param calculator    The calculator that holds the zone's position
+     */
+    private fun isWithinZone(event: MotionEvent, calculator: Calculator?): Boolean {
+        var isWithin = false
+        val x = event.x
+        val y = event.y
+        val focusCenterX = calculator?.circleCenterX ?: 0
+        val focusCenterY = calculator?.circleCenterY ?: 0
+        val focusWidth = calculator?.focusWidth ?: 0
+        val focusHeight = calculator?.focusHeight ?: 0
+        val focusRadius =
+                if (FocusShape.CIRCLE == mFocusShape)
+                    calculator?.circleRadius(0, 1.0) ?: 0f
+                else 0f
+
+        when (mFocusShape) {
+            FocusShape.CIRCLE -> {
+                val distance = Math.sqrt(
+                        Math.pow((focusCenterX - x).toDouble(), 2.0) + Math.pow((focusCenterY - y).toDouble(), 2.0))
+
+                isWithin = Math.abs(distance) < focusRadius
+            }
+            FocusShape.ROUNDED_RECTANGLE -> {
+                val rect = Rect()
+                val left = focusCenterX - focusWidth / 2
+                val right = focusCenterX + focusWidth / 2
+                val top = focusCenterY - focusHeight / 2
+                val bottom = focusCenterY + focusHeight / 2
+                rect.set(left, top, right, bottom)
+                isWithin = rect.contains(x.toInt(), y.toInt())
+            }
         }
 
+        return isWithin
     }
 
     /**
@@ -475,7 +486,7 @@ class FancyShowCaseView : FrameLayout, ViewTreeObserver.OnGlobalLayoutListener {
                 }
 
                 if (autoPosText) {
-                    calculator?.calcAutoTextPosition(textView)
+                    focusCalculator?.calcAutoTextPosition(textView)
                 }
             }
         })
@@ -591,6 +602,7 @@ class FancyShowCaseView : FrameLayout, ViewTreeObserver.OnGlobalLayoutListener {
      */
     class Builder(private val activity: Activity) {
         private var focusedView: View? = null
+        private var clickableView: View? = null
         private var mId: String? = null
         private var mTitle: String? = null
         private var mSpannedTitle: Spanned? = null
@@ -702,6 +714,15 @@ class FancyShowCaseView : FrameLayout, ViewTreeObserver.OnGlobalLayoutListener {
          */
         fun showOnce(id: String): Builder {
             mId = id
+            return this
+        }
+
+        /**
+         * @param view view to focus
+         * @return Builder
+         */
+        fun clickableOn(view: View): Builder {
+            clickableView = view
             return this
         }
 
@@ -890,7 +911,7 @@ class FancyShowCaseView : FrameLayout, ViewTreeObserver.OnGlobalLayoutListener {
          * @return [FancyShowCaseView] with given parameters
          */
         fun build(): FancyShowCaseView {
-            return FancyShowCaseView(activity, focusedView, mId, mTitle, mSpannedTitle, mTitleGravity, mTitleStyle, mTitleSize, mTitleSizeUnit,
+            return FancyShowCaseView(activity, focusedView, clickableView, mId, mTitle, mSpannedTitle, mTitleGravity, mTitleStyle, mTitleSize, mTitleSizeUnit,
                     focusCircleRadiusFactor, mBackgroundColor, mFocusBorderColor, mFocusBorderSize, mCustomViewRes, viewInflateListener,
                     mEnterAnimation, mExitAnimation, mAnimationListener, mCloseOnTouch, mEnableTouchOnFocusedView, fitSystemWindows, mFocusShape, mDismissListener, mRoundRectRadius,
                     mFocusPositionX, mFocusPositionY, mFocusCircleRadius, mFocusRectangleWidth, mFocusRectangleHeight, focusAnimationEnabled,


### PR DESCRIPTION
Hi @faruktoptas,

I've been wandering around your lib and it's a very good job you did there. It just happened that I need to let the touch through the focused zone and was happy to found that you had thought about it :)
Unfortunately it doesn't work and I figured quickly the issue while looking at the code. Your getters are called only once using equal while you should override the get. Since your calculator is initialized once the focus method is called it is even more important to do so.
As a bonus I also removed all your constructors with the JvmOverload annotation. I can remove it if your not keen to use this ;)
Finally I'll try to work on another feature that I would very much like to have using your library which is enabling touch on a particular zone within the focused zone. This would allow me to highlight a view while having only part of it clickable.
I'll submit a PR if I manage to do that ;)
Cheers,
Stephen