### PR TITLE
Continue queue on skipped showcases

### DIFF
--- a/fancyshowcaseview/src/main/java/me/toptas/fancyshowcase/FancyShowCaseView.kt
+++ b/fancyshowcaseview/src/main/java/me/toptas/fancyshowcase/FancyShowCaseView.kt
@@ -92,13 +92,16 @@ class FancyShowCaseView @JvmOverloads constructor(context: Context, attrs: Attri
 
     var queueListener: OnQueueListener? = null
 
+    private inner class QueueListenerProxy : OnQueueListener {
+        override fun onNext() = queueListener?.onNext() ?: Unit
+    }
 
     private constructor(_activity: Activity, _props: Properties, _androidProps: AndroidProperties) : this(_activity) {
         props = _props
         activity = _activity
         androidProps = _androidProps
         val deviceParams = DeviceParamsImpl(activity, this)
-        presenter = Presenter(preferences(activity), deviceParams, props)
+        presenter = Presenter(preferences(activity), deviceParams, props.copy(queueListener = QueueListenerProxy()))
         animationPresenter = AnimationPresenter(androidProps, deviceParams)
 
         presenter.initialize()

--- a/fancyshowcaseview/src/main/java/me/toptas/fancyshowcase/internal/Presenter.kt
+++ b/fancyshowcaseview/src/main/java/me/toptas/fancyshowcase/internal/Presenter.kt
@@ -45,6 +45,7 @@ internal class Presenter(private val pref: SharedPref,
     fun show(onShow: () -> Unit/*, waitForLayout: () -> Unit*/) {
         if (pref.isShownBefore(props.fancyId)) {
             props.dismissListener?.onSkipped(props.fancyId)
+            props.queueListener?.onNext()
             return
         }
         // if view is not laid out get, width/height values in onGlobalLayout


### PR DESCRIPTION
Hi!
We experienced the behaviour that one "skipped" showcase that has already been shown blocks the whole queue behind it as it never called `onNext()` to continue with the queue.

The queue could still have elements that were not shown. E.g. if the user stops the showcase tour or switches to another app only a part could have been shown.

In current `master` branch it is a simple call. As with the new Presenter architecture, the `queueListener` in `props` is not set, I had to make it available.

Passing a proxy allowing for the actual listener to be set later (after the constructing call) seemed appropriate. Please comment if you would prefer another approach.

Thanks for the great library! :) 