### PR TITLE
Fixed markdown file name and remove unwanted trailing "." at headings

### DIFF
--- a/ISSUE-TEMPLATE.md
+++ b/ISSUE-TEMPLATE.md
@@ -1,6 +1,6 @@
 ### Used FancyShowCaseView version
 
-### Screenshot if there is something wrong with ui.
+### Screenshot if there is something wrong with ui
 
 ### How you show/hide FancyShowCaseView (in Activity or Fragment, in which method)
 


### PR DESCRIPTION
This is to fix the issues mentioned in https://app.codacy.com/manual/faruktoptas/FancyShowCaseView/file/44461760070/issues/source?bid=14909056&fileBranchId=14909056#l1