### PR TITLE
Scaled focus view

### DIFF
--- a/app/src/main/java/me/toptas/fancyshowcasesample/MainActivity.kt
+++ b/app/src/main/java/me/toptas/fancyshowcasesample/MainActivity.kt
@@ -296,6 +296,14 @@ class MainActivity : BaseActivity() {
             startActivity(Intent(this, RecyclerViewActivity::class.java))
         }
 
+        btn_scaled_view.setOnClickListener {
+            FancyShowCaseView.Builder(this)
+                    .focusOn(it)
+                    .title("Focus on Scaled View")
+                    .build()
+                    .show()
+        }
+
         btn_focus_delay.setOnClickListener {
             FancyShowCaseView.Builder(this)
                     .title("Focus with delay")

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -236,5 +236,15 @@
             android:layout_marginTop="@dimen/default_margin"
             android:text="Using with RecyclerView" />
 
+        <Button
+            android:id="@+id/btn_scaled_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/double_margin"
+            android:layout_marginBottom="@dimen/double_margin"
+            android:scaleX="1.5"
+            android:scaleY="1.5"
+            android:text="Scaled Button" />
+
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -19,4 +19,5 @@
     <dimen name="activity_horizontal_margin">16dp</dimen>
     <dimen name="activity_vertical_margin">16dp</dimen>
     <dimen name="default_margin">10dp</dimen>
+    <dimen name="double_margin">20dp</dimen>
 </resources>

--- a/fancyshowcaseview/src/main/java/me/toptas/fancyshowcase/internal/IFocusedView.kt
+++ b/fancyshowcaseview/src/main/java/me/toptas/fancyshowcase/internal/IFocusedView.kt
@@ -14,9 +14,9 @@ internal interface IFocusedView {
 
 internal class FocusedView(private val view: View) : IFocusedView {
 
-    override fun width() = view.width
+    override fun width() = (view.scaleX * view.width.toFloat()).toInt()
 
-    override fun height() = view.height
+    override fun height() = (view.scaleY * view.height.toFloat()).toInt()
 
     override fun getLocationInWindow(viewPoint: IntArray): IntArray {
         view.getLocationInWindow(viewPoint)


### PR DESCRIPTION
If a view to focus is scaled, then the size and the center of the focus area is wrongly calculated. This patch resolves the issue.