### PR TITLE
added isHiding to avoid restart exit animation

### DIFF
--- a/fancyshowcaseview/src/main/java/me/toptas/fancyshowcase/FancyShowCaseView.kt
+++ b/fancyshowcaseview/src/main/java/me/toptas/fancyshowcase/FancyShowCaseView.kt
@@ -77,6 +77,7 @@ class FancyShowCaseView @JvmOverloads constructor(context: Context, attrs: Attri
     private var mCenterY: Int = 0
     private var mRoot: ViewGroup? = null
     private var fancyImageView: FancyImageView? = null
+    private var isHiding = false
 
     val focusCenterX: Int
         get() = presenter.circleCenterX
@@ -200,6 +201,9 @@ class FancyShowCaseView @JvmOverloads constructor(context: Context, attrs: Attri
      * Hides FancyShowCaseView with animation
      */
     fun hide() {
+        if(isHiding) return
+        isHiding = true
+
         if (androidProps.exitAnimation != null) {
             if (androidProps.exitAnimation is FadeOutAnimation && shouldShowCircularAnimation()) {
                 doCircularExitAnimation()
@@ -324,6 +328,7 @@ class FancyShowCaseView @JvmOverloads constructor(context: Context, attrs: Attri
         mRoot?.removeView(this)
         props.dismissListener?.onDismiss(props.fancyId)
         queueListener?.onNext()
+        isHiding = false
     }
 
     private fun shouldShowCircularAnimation(): Boolean {


### PR DESCRIPTION
Fixes issue #229 
Got able to reproduce it very clearly at the Sample App by using the "CUSTOM ANIMATION" button, and tapping it during exit animation.

My solution avoids restarting exit animation by caching a flag and then checking as a guard on any future call. 
It works, but it doesn't seems very polished, I'm open to rewrite if you have suggestion.