### PR TITLE
Sample Only Change - separating basic circle focus and show once behaviour

### DIFF
--- a/app/src/main/java/me/toptas/fancyshowcasesample/MainActivity.kt
+++ b/app/src/main/java/me/toptas/fancyshowcasesample/MainActivity.kt
@@ -62,8 +62,7 @@ class MainActivity : BaseActivity() {
         btn_focus.setOnClickListener {
             FancyShowCaseView.Builder(this)
                     .focusOn(it)
-                    .title("Focus on View only once")
-                    .showOnce("id0")
+                    .title("Circle Focus on View")
                     .build()
                     .show()
         }
@@ -341,6 +340,15 @@ class MainActivity : BaseActivity() {
                     .title("Focus with delay")
                     .focusOn(it)
                     .delay(1000)
+                    .build()
+                    .show()
+        }
+
+        btn_show_once.setOnClickListener {
+            FancyShowCaseView.Builder(this)
+                    .focusOn(it)
+                    .title("Clean storage to see this again")
+                    .showOnce("id0")
                     .build()
                     .show()
         }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -177,12 +177,26 @@
             android:text="Dashed Circle Border" />
     </LinearLayout>
 
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:orientation="horizontal">
+
         <Button
             android:id="@+id/btn_focus_delay"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/default_margin"
             android:text="Delayed" />
+
+        <Button
+            android:id="@+id/btn_show_once"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/default_margin"
+            android:text="Show once" />
+    </LinearLayout>
 
         <LinearLayout
             android:layout_width="wrap_content"


### PR DESCRIPTION
That was causing a confusion on myself, I didn't read the title as I first open the "circle" button and not seeing it appear again made me thought things were incorrect.
Ends up, that is a showOnce button.
So I have separated the behaviour for better clarity.